### PR TITLE
butane: New example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ functionality.
 
 - [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
 - [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora
+- [butane](butane/): Demos using https://github.com/coreos/butane

--- a/butane/Dockerfile
+++ b/butane/Dockerfile
@@ -1,0 +1,15 @@
+# TODO https://github.com/coreos/butane/pull/338
+FROM quay.io/cgwalters/butane as butane
+# See the butane file for configuration changes
+ADD demo.bu /demo.bu
+# Compile to ignition
+RUN butane --pretty --strict demo.bu > /demo.ign
+
+FROM quay.io/coreos-assembler/fcos:testing-devel
+# First workaround ignition-liveapply not being shipped yet.
+RUN rpm -Uvh https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-35-x86_64/03938171-ignition/ignition-2.13.0.63.g919102e7-5.fc35.x86_64.rpm && \
+    ln -sr /usr/lib/dracut/modules.d/30ignition/ignition /usr/bin/ignition-apply
+# Copy our generated Ignition
+COPY --from=butane /demo.ign demo.ign
+# Now apply it to the live filesystem, and clean it up
+RUN ignition-apply demo.ign && rm -f demo.ign && ostree container commit

--- a/butane/demo.bu
+++ b/butane/demo.bu
@@ -1,0 +1,27 @@
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    # Configure chrony to use custom servers
+    - path: /etc/chrony.conf
+      overwrite: true
+      contents:
+        inline: |
+          server foo.example.net maxdelay 0.4 offline
+          server bar.example.net maxdelay 0.4 offline
+          server baz.example.net maxdelay 0.4 offline
+          driftfile /var/lib/chrony/drift
+          makestep 1.0 3
+          rtcsync
+          logdir /var/log/chrony
+      mode: 0644
+systemd:
+  units:
+    - name: serial-getty@ttyS0.service
+      dropins:
+        - name: autologin.conf
+          contents: |
+            [Service]
+            TTYVTDisallocate=no
+            ExecStart=
+            ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM


### PR DESCRIPTION
We have a lot of useful syntax and semantics in Butane, and it
helps tie our story to Ignition.

(What would be interesting is a tool that "splits" an butane/Ignition
 into things like `storage` that need to be firstboot config, and
 builds the rest as a container)