### PR TITLE
wifi: New example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ functionality.
 ## Examples
 
 - [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
+- [wifi](wifi/): Install support for wireless networks along with pre-baked configuration to join a network
 - [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora

--- a/wifi/Dockerfile
+++ b/wifi/Dockerfile
@@ -1,0 +1,7 @@
+# Install wireless support along with a static configuration file.
+FROM quay.io/coreos-assembler/fcos:testing-devel
+RUN rpm-ostree install NetworkManager-wifi NetworkManager-wwan wpa_supplicant wireless-regdb && \
+    rpm-ostree cleanup -m && \
+    ostree container commit
+# And also inject a configuration
+ADD ExampleCorpWifi.ini /etc/NetworkManager/system-connections/

--- a/wifi/ExampleCorpWifi.ini
+++ b/wifi/ExampleCorpWifi.ini
@@ -1,0 +1,29 @@
+[connection]
+id=ExampleCorpWiFi
+uuid=6ad20506-0f78-4060-980b-820b7508efba
+type=wifi
+interface-name=wlp4s0
+permissions=
+
+[wifi]
+mac-address-blacklist=
+mode=infrastructure
+ssid=ExampleCorpWiFi
+
+[wifi-security]
+auth-alg=open
+key-mgmt=wpa-psk
+# TODO: see https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/106
+# We should also have an opinionated story for managing secrets in Ignition + derivation.
+psk=examplekeyhere
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]


### PR DESCRIPTION
Support for wireless on FCOS has come up several times, and is
one of the notable differences with current Fedora IoT.  It also
highlights a gap in our support for secret management.