### PR TITLE
Add a selinux example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ functionality.
 
 - [butane](butane/): Demos using https://github.com/coreos/butane
 - [wifi](wifi/): Install support for wireless networks along with pre-baked configuration to join a network
+- [selinux](selinux/): Demos changing a SELinux boolean
 - [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
 - [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ functionality.
 
 ## Examples
 
-- [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
-- [wifi](wifi/): Install support for wireless networks along with pre-baked configuration to join a network
-- [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora
 - [butane](butane/): Demos using https://github.com/coreos/butane
+- [wifi](wifi/): Install support for wireless networks along with pre-baked configuration to join a network
+- [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
+- [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora
 
 ## Running an example
 

--- a/selinux/Dockerfile
+++ b/selinux/Dockerfile
@@ -1,0 +1,9 @@
+# Change a SELinux boolean.  The first line is a workaround for a conflict
+# between overlayfs semantics and libselinux that is on track to being fixed, see
+# https://github.com/SELinuxProject/selinux/pull/342
+FROM quay.io/coreos-assembler/fcos:testing-devel
+# See above; temporary work around; this should be fixed in newer libselinux.  Note
+# that this `mv` incantation *must* be in the same RUN line (i.e. same layer) as
+# the policy changes.
+RUN mv /etc/selinux/targeted/active{,.tmp} && mv /etc/selinux/targeted/active{.tmp,} && \
+    setsebool -P -N container_manage_cgroup 1


### PR DESCRIPTION
README.md: Reorder examples

I think `inject-go-binary` is interesting but probably
not enough to be first.

---

Add a selinux example

Crucially this documents the hopefully-temporary workaround.

---

