### PR TITLE
Add ci to generate examples in rhcos branch

### DIFF
--- a/.github/workflows/generate-rhcos-versions.yml
+++ b/.github/workflows/generate-rhcos-versions.yml
@@ -1,0 +1,39 @@
+name: Generate RHCOS versions
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-rhcos-versions:
+    name: generate rhcos versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: generate rhcos versions
+        run: ci/generate-rhcos-versions.py
+      - name: Create commit
+        run: |
+          git config user.name 'CoreOS Bot'
+          git config user.email coreosbot@fedoraproject.org
+          if ! git diff --quiet --exit-code; then
+              git commit -am "examples: generate rhcos versions ✨" \
+                  -m "Triggered by generate-rhcos-versions GitHub Action."
+          fi
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          branch: generate-rhcos-versions
+          push-to-fork: coreosbot-releng/coreos-layering-examples
+          base: rhcos
+          commit-message: "examples: generate rhcos versions"
+          title: "examples: generate rhcos versions"
+          body: "Created by generate-rhcos-versions [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/generate-rhcos-versions.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/generate-rhcos-versions.yml))."
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"

--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+# Update Dockerfiles to use rhcos images.
+
+import os
+import requests
+import sys
+import yaml
+
+RHCOS_IMAGE = 'registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11'
+RHEL_REPOS = '#You will need the RHEL repos in a file.\nADD rhel.repo /etc/yum.repos.d'
+FCOS_IMAGE = 'quay.io/coreos-assembler/fcos:testing-devel'
+
+basedir = os.path.normpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+for root, dirs, files in os.walk(basedir):
+    for file in files:
+        if file.endswith("Dockerfile"):
+             print("Generating RHCOS version of:" + os.path.join(root, file))
+             path = os.path.join(basedir, os.path.join(root, file))
+             with open(path, "rt") as f:
+                 content = f.read().replace(FCOS_IMAGE, RHCOS_IMAGE+'\n'+RHEL_REPOS)
+             with open(path, "wt") as f:
+                 f.write(content)


### PR DESCRIPTION
Does initial generation of the rhcos branch by changing the FROM lines on any Dockerfiles found.

For this to work I think we need:
- create rhcos branch based on the current main branch on this repository.
- to add the https://github.com/coreosbot-releng token to the secrets in this repository.
- fork this repository to github.com/coreosbot-releng/coreos-layering-examples

At least based on my tests with my forks that should make it work. But I don't have the credentials or access to do these things I believe.