### PR TITLE
examples: generate rhcos versions

### DIFF
--- a/ansible-firewalld/Dockerfile
+++ b/ansible-firewalld/Dockerfile
@@ -1,6 +1,8 @@
 # This example uses Ansible to configure firewalld to set up a node-local firewall suitable as recommended for use as an OpenShift 4 worker.
 # However, this is intended to generalize to using Ansible as well as firewalld for generic tasks.
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11
+#You will need the RHEL repos in a file.
+ADD rhel.repo /etc/yum.repos.d
 
 # Install firewalld and ansible
 RUN rpm-ostree install firewalld ansible

--- a/butane/Dockerfile
+++ b/butane/Dockerfile
@@ -5,7 +5,9 @@ ADD demo.bu /demo.bu
 # Compile to ignition
 RUN butane --pretty --strict demo.bu > /demo.ign
 
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11
+#You will need the RHEL repos in a file.
+ADD rhel.repo /etc/yum.repos.d
 # First workaround ignition-liveapply not being shipped yet.
 RUN rpm -Uvh https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-35-x86_64/03938171-ignition/ignition-2.13.0.63.g919102e7-5.fc35.x86_64.rpm && \
     ln -sr /usr/lib/dracut/modules.d/30ignition/ignition /usr/bin/ignition-apply

--- a/selinux/Dockerfile
+++ b/selinux/Dockerfile
@@ -1,7 +1,9 @@
 # Change a SELinux boolean.  The first line is a workaround for a conflict
 # between overlayfs semantics and libselinux that is on track to being fixed, see
 # https://github.com/SELinuxProject/selinux/pull/342
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11
+#You will need the RHEL repos in a file.
+ADD rhel.repo /etc/yum.repos.d
 # See above; temporary work around; this should be fixed in newer libselinux.  Note
 # that this `mv` incantation *must* be in the same RUN line (i.e. same layer) as
 # the policy changes.

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -1,7 +1,9 @@
 # This is like https://tailscale.com/download/linux/fedora
 # except it happens as part of a container build!  You then need to do
 # `tailscale up` via some other mechanism.
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11
+#You will need the RHEL repos in a file.
+ADD rhel.repo /etc/yum.repos.d
 RUN cd /etc/yum.repos.d/ && curl -LO https://pkgs.tailscale.com/stable/fedora/tailscale.repo && \
     rpm-ostree install tailscale && rpm-ostree cleanup -m && \
     systemctl enable tailscaled && \

--- a/wifi/Dockerfile
+++ b/wifi/Dockerfile
@@ -1,5 +1,7 @@
 # Install wireless support along with a static configuration file.
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:4.11
+#You will need the RHEL repos in a file.
+ADD rhel.repo /etc/yum.repos.d
 RUN rpm-ostree install NetworkManager-wifi NetworkManager-wwan wpa_supplicant wireless-regdb && \
     rpm-ostree cleanup -m && \
     ostree container commit


### PR DESCRIPTION
Created by generate-rhcos-versions [GitHub workflow](https://github.com/coreos/coreos-layering-examples/actions/workflows/generate-rhcos-versions.yml) ([source](https://github.com/coreos/coreos-layering-examples/blob/main/.github/workflows/generate-rhcos-versions.yml)).