### PR TITLE
replace-systemd: new example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ functionality.
 - [selinux](selinux/): Demos changing a SELinux boolean
 - [inject-go-binary](inject-go-binary/): Demos adding building and injecting a Go binary + systemd unit
 - [tailscale](tailscale/): Demos https://tailscale.com/download/linux/fedora
+- [replace-systemd](replace-systemd/): Replacing a base package, in this case systemd
 
 ## Running an example
 

--- a/replace-systemd/Dockerfile
+++ b/replace-systemd/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/coreos-assembler/fcos:testing-devel
+RUN rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2022-0bbb402870 && \
+    rpm-ostree cleanup -m && \
+    ostree container commit


### PR DESCRIPTION
Minimal example showing replacement of a base core package like systemd
directly from Bodhi.