### PR TITLE
generate-rhcos-versions: Only inject `ADD rhel.repo` if needed

### DIFF
--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -19,7 +19,7 @@ for root, dirs, files in os.walk(basedir):
         with open(path, "rt") as f:
             contents = f.read()
         replacement = RHCOS_IMAGE
-        if contents.find('rpm-ostree install') >= 0:
+        if 'rpm-ostree install' in contents:
             replacement = f"{replacement}\n{RHEL_REPOS}"
         print("Generating RHCOS version of:" + os.path.join(root, name))
         new_contents = contents.replace(FCOS_IMAGE, replacement)

--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -12,10 +12,10 @@ FCOS_IMAGE = 'quay.io/coreos-assembler/fcos:testing-devel'
 
 basedir = os.path.normpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 for root, dirs, files in os.walk(basedir):
-    for file in files:
-        if file.endswith("Dockerfile"):
-             print("Generating RHCOS version of:" + os.path.join(root, file))
-             path = os.path.join(basedir, os.path.join(root, file))
+    for name in files:
+        if name.endswith("Dockerfile"):
+             print("Generating RHCOS version of:" + os.path.join(root, name))
+             path = os.path.join(basedir, os.path.join(root, name))
              with open(path, "rt") as f:
                  content = f.read().replace(FCOS_IMAGE, RHCOS_IMAGE+'\n'+RHEL_REPOS)
              with open(path, "wt") as f:

--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -13,10 +13,11 @@ FCOS_IMAGE = 'quay.io/coreos-assembler/fcos:testing-devel'
 basedir = os.path.normpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 for root, dirs, files in os.walk(basedir):
     for name in files:
-        if name.endswith("Dockerfile"):
-             print("Generating RHCOS version of:" + os.path.join(root, name))
-             path = os.path.join(basedir, os.path.join(root, name))
-             with open(path, "rt") as f:
-                 content = f.read().replace(FCOS_IMAGE, RHCOS_IMAGE+'\n'+RHEL_REPOS)
-             with open(path, "wt") as f:
-                 f.write(content)
+        if not name.endswith("Dockerfile"):
+            continue
+        print("Generating RHCOS version of:" + os.path.join(root, name))
+        path = os.path.join(basedir, os.path.join(root, name))
+        with open(path, "rt") as f:
+            content = f.read().replace(FCOS_IMAGE, RHCOS_IMAGE+'\n'+RHEL_REPOS)
+        with open(path, "wt") as f:
+            f.write(content)

--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -21,7 +21,7 @@ for root, dirs, files in os.walk(basedir):
         replacement = RHCOS_IMAGE
         if 'rpm-ostree install' in contents:
             replacement = f"{replacement}\n{RHEL_REPOS}"
-        print("Generating RHCOS version of:" + os.path.join(root, name))
+        print("Generating RHCOS version of: " + os.path.join(root, name))
         new_contents = contents.replace(FCOS_IMAGE, replacement)
         if contents == new_contents:
             print(f"No changes to {path}")

--- a/ci/generate-rhcos-versions.py
+++ b/ci/generate-rhcos-versions.py
@@ -15,9 +15,16 @@ for root, dirs, files in os.walk(basedir):
     for name in files:
         if not name.endswith("Dockerfile"):
             continue
-        print("Generating RHCOS version of:" + os.path.join(root, name))
         path = os.path.join(basedir, os.path.join(root, name))
         with open(path, "rt") as f:
-            content = f.read().replace(FCOS_IMAGE, RHCOS_IMAGE+'\n'+RHEL_REPOS)
-        with open(path, "wt") as f:
-            f.write(content)
+            contents = f.read()
+        replacement = RHCOS_IMAGE
+        if contents.find('rpm-ostree install') >= 0:
+            replacement = f"{replacement}\n{RHEL_REPOS}"
+        print("Generating RHCOS version of:" + os.path.join(root, name))
+        new_contents = contents.replace(FCOS_IMAGE, replacement)
+        if contents == new_contents:
+            print(f"No changes to {path}")
+        else:
+            with open(path, "wt") as f:
+                f.write(new_contents)


### PR DESCRIPTION
generate-rhcos-versions: s/file/name/

`file` is a builtin Python keyword, we shouldn't override it.

---

generate-rhcos-versions: De-indent loop

It's more readable this way.

---

generate-rhcos-versions: Only inject `ADD rhel.repo` if needed

Only some of the examples actually install packages, not all.
In particular the `selinux` one does not, and I want to use it
as a test case to fix https://github.com/openshift/os/issues/829

I'm thinking actually we should drop this bit entirely and rely
on host subscriptions *or* users doing it on their own, but
for now this works.

---

