### PR TITLE
inject-go-binary: use FCOS `testing-devel` like everything else

### DIFF
--- a/inject-go-binary/Dockerfile
+++ b/inject-go-binary/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN yum -y install go-toolset
 RUN go build hello-world.go
 
-FROM quay.io/coreos-assembler/fcos:next-devel
+FROM quay.io/coreos-assembler/fcos:testing-devel
 # Inject it into Fedora CoreOS
 COPY --from=builder /build/hello-world /usr/bin
 # And add our unit file


### PR DESCRIPTION
I noticed when working on https://github.com/coreos/coreos-layering-examples
that the rhcos substitution was failing on this one because it
doesn't match `next-devel`.

(Potentially we should fix that *too*, but eh, no reason not to make
 things consistent either)