### PR TITLE
podman-next: Add example using latest podman from COPR repo

### DIFF
--- a/.github/workflows/podman-next.yml
+++ b/.github/workflows/podman-next.yml
@@ -1,0 +1,34 @@
+name: "Build image: podman-next"
+
+env:
+  IMAGE_NAME: "podman-next"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - podman-next/*
+      - .github/workflows/podman-next.yml
+  push:
+    branches:
+      - main
+    paths:
+      - podman-next/*
+      - .github/workflows/podman-next.yml
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Build container image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: ${{ env.IMAGE_NAME }}
+          containerfiles: ${{ env.IMAGE_NAME }}/Containerfile
+          image: ${{ env.IMAGE_NAME }}
+          layers: false
+          oci: true

--- a/podman-next/Containerfile
+++ b/podman-next/Containerfile
@@ -1,0 +1,18 @@
+FROM quay.io/fedora/fedora-coreos:stable
+
+# Note: This needs to be updated to the next Fedora release manually. The repo
+# config itself is release agnotic but the link will be broken once the F36
+# buildroot is removed.
+ENV PODMAN_COPR="https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-36/rhcontainerbot-podman-next-fedora-36.repo"
+ENV REPO="copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next"
+
+# - Fetch podman-next copr config
+# - Replace aardvark-dns, conmon, crun, netavark, podman, containers-common
+# - Remove moby-engine, containerd, runc
+#   Note that this requires squashing the image to get a size reduction.
+RUN curl -o /etc/yum.repos.d/podman-next.repo "$PODMAN_COPR" && \
+    rpm-ostree override replace --experimental --freeze --from repo="$REPO" \
+        aardvark-dns conmon crun netavark podman containers-common && \
+    rpm-ostree override remove moby-engine containerd runc && \
+    rpm-ostree cleanup -m && \
+    ostree container commit


### PR DESCRIPTION
This will enable podman folks to use that for their custom FCOS builds for podman machine.