### PR TITLE
build-zfs-module: Add example building a kernel module

### DIFF
--- a/.github/workflows/build-zfs-module.yml
+++ b/.github/workflows/build-zfs-module.yml
@@ -1,0 +1,34 @@
+name: "Build image: build-zfs-module"
+
+env:
+  IMAGE_NAME: "build-zfs-module"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - build-zfs-module/*
+      - .github/workflows/build-zfs-module.yml
+  push:
+    branches:
+      - main
+    paths:
+      - build-zfs-module/*
+      - .github/workflows/build-zfs-module.yml
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Build container image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: ${{ env.IMAGE_NAME }}
+          containerfiles: ${{ env.IMAGE_NAME }}/Containerfile
+          image: ${{ env.IMAGE_NAME }}
+          layers: false
+          oci: true

--- a/build-zfs-module/Containerfile
+++ b/build-zfs-module/Containerfile
@@ -1,0 +1,35 @@
+ARG ZFS_VERSION=2.1.6
+ARG BUILDER_VERSION=36
+
+FROM quay.io/fedora/fedora-coreos:stable as kernel-query
+#We can't use the `uname -r` as it will pick up the host kernel version
+RUN rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' > /kernel-version.txt
+
+# Using https://openzfs.github.io/openzfs-docs/Developer%20Resources/Custom%20Packages.html
+FROM registry.fedoraproject.org/fedora:${BUILDER_VERSION} as builder
+ARG ZFS_VERSION
+ARG BUILDER_VERSION
+COPY --from=kernel-query /kernel-version.txt /kernel-version.txt
+WORKDIR /etc/yum.repos.d
+RUN curl -L -O https://src.fedoraproject.org/rpms/fedora-repos/raw/f${BUILDER_VERSION}/f/fedora-updates-archive.repo && \
+    sed -i 's/enabled=AUTO_VALUE/enabled=true/' fedora-updates-archive.repo
+RUN dnf install -y dkms gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel \
+    libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel \
+    kernel-$(cat /kernel-version.txt) kernel-modules-$(cat /kernel-version.txt) kernel-devel-$(cat /kernel-version.txt) \
+    python3 python3-devel python3-setuptools python3-cffi libffi-devel git ncompress libcurl-devel
+WORKDIR /
+RUN curl -L -O https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz && tar xzf zfs-${ZFS_VERSION}.tar.gz
+WORKDIR /zfs-${ZFS_VERSION}
+RUN ./configure -with-linux=/usr/src/kernels/$(cat /kernel-version.txt)/ -with-linux-obj=/usr/src/kernels/$(cat /kernel-version.txt)/ \
+    && make -j1 rpm-utils rpm-kmod
+
+FROM quay.io/fedora/fedora-coreos:stable
+ARG ZFS_VERSION
+COPY --from=builder /zfs-${ZFS_VERSION}/*.rpm /
+# For the example we install all RPMS (debug, test, etc).
+# In real use cases probably just want the module rpm.
+RUN rpm-ostree install /*.$(uname -p).rpm && \
+    # we don't want any files on /var
+    rm -rf /var/lib/pcp && \
+    rpm-ostree cleanup -m && \
+    ostree container commit 


### PR DESCRIPTION
Co-authored-by: Micah Abbott

This example builds the rpms for the ZFS module using multi stage builds.

Few fun things learned from this: @ashcrow found out that `ld` is not properly installed on CoreOS/Silverblue it looks like it's the %post script failing. I found out that because the Makefile tries to create a folder using 'mkdir -p /usr/local/X' and `/usr/local` is a link to `/var/usrlocal` it fails. Based on these two constraints building in a intermediate fedora application container(non-ostree) seems like the best way forward at the moment.

Closes #40 